### PR TITLE
chore: fix accept typo on homepage

### DIFF
--- a/lib/textdb_web/templates/page/index.html.eex
+++ b/lib/textdb_web/templates/page/index.html.eex
@@ -18,7 +18,7 @@
 
 <section class="more-info">
   <p>Additional Information</p>
-  <p>Textdb should respect your headers, say if you do -H "accepts: application/json" it will return json.</p>
+  <p>Textdb should respect your headers, say if you do -H "accept: application/json" it will return json.</p>
   <p>Likewise, if you do -H "content-type: application/json" when posting, it will validate the json.</p>
   <p>If you have the data open on your browser, it should live update on writes.</p>
   <p>Yes, anyone with the link can edit the data.</p>


### PR DESCRIPTION
Replace `accepts` by `accept`
See https://developer.mozilla.org/en-US/docs/Web/HTTP/Headers/Accept
https://github.com/bontaq/textdb/blob/23a22a1ec19d71732b936014042aa4d128c6adef/lib/textdb_web/controllers/api_controller.ex